### PR TITLE
Updated pgquota to handle the NFS mounted file system

### DIFF
--- a/pgquota/pgquota
+++ b/pgquota/pgquota
@@ -107,7 +107,34 @@ class Quota:
     # Then we can print it or not
     def __init__(self, group, directory, debug_flag):
         self.group = group
-        self.directory = directory
+        print(self.group)
+        if directory == '/home':
+           if os.path.isdir(os.path.join('/home2', gname(self.group))):
+              self.directory = '/home'
+        else:
+           self.directory = directory
+      
+        if self.directory == '/home2': 
+           self.quota_zfsnfs(debug_flag)
+        else:
+           self.quota_lustre(debug_flag)
+        
+        if debug_flag:
+            print(Color.red("Debug object variables"))
+            print(
+                "Disk Usage: {}	{}\nDisk Allocated: {}	{}\nDisk Limit: {}	{}\nFile Usage: {}	{}\nFile Allocated: {}	{}\nFile Limit: {}	{}\nDisk Grace: {}	{}\nFile Grace: {}	{}".format(
+                    self.dusage, type(self.dusage), self.dalloc, type(self.dalloc), self.dlimit, type(self.dlimit),
+                    self.fusage, type(self.fusage), self.falloc, type(self.falloc), self.flimit, type(self.flimit),
+                    self.dgrace, type(self.dgrace), self.fgrace, type(self.fgrace)))
+            print(Color.red("End Debug object variables"))
+        self.bar = percent_bar(float((float(self.dusage) / float(self.dalloc)) * 100))
+        # some more empty internal variables
+        self._warn_use = None
+        self._warn_files = None
+        # functions to call
+        self.gen_warnings()
+
+    def quota_lustre(self,debug_flag):
         self.raw = subprocess.check_output(['lfs', 'quota', '-g', str(self.group), str(self.directory), '-h']).decode(
             "utf-8")
         if debug_flag:
@@ -133,20 +160,10 @@ class Quota:
         self.fgrace = self.ref[8]
         if self.fgrace == "none":
             self.fgrace = self.fgrace.upper()
-        if debug_flag:
-            print(Color.red("Debug object variables"))
-            print(
-                "Disk Usage: {}	{}\nDisk Allocated: {}	{}\nDisk Limit: {}	{}\nFile Usage: {}	{}\nFile Allocated: {}	{}\nFile Limit: {}	{}\nDisk Grace: {}	{}\nFile Grace: {}	{}".format(
-                    self.dusage, type(self.dusage), self.dalloc, type(self.dalloc), self.dlimit, type(self.dlimit),
-                    self.fusage, type(self.fusage), self.falloc, type(self.falloc), self.flimit, type(self.flimit),
-                    self.dgrace, type(self.dgrace), self.fgrace, type(self.fgrace)))
-            print(Color.red("End Debug object variables"))
-        self.bar = percent_bar(float((float(self.dusage) / float(self.dalloc)) * 100))
-        # some more empty internal variables
-        self._warn_use = None
-        self._warn_files = None
-        # functions to call
-        self.gen_warnings()
+
+
+    def quota_zfsnfs(self,debug_flag):
+        return
 
     def check_raw(self):
         # checks for messages like "Permission denied."

--- a/pgquota/pgquota
+++ b/pgquota/pgquota
@@ -104,9 +104,9 @@ def convert_bytes(num):
 
     for x in ['bytes', 'KiB', 'MiB', 'GiB', 'TiB']:
         if num < step_unit:
-            return "{:.1f} {}".format (num, x)
+            return "{:.1f} {}".format(num, x)
         num /= step_unit
-    return "{:.1f} {}".format (num, 'PiB')
+    return "{:.1f} {}".format(num, 'PiB')
 
 def strip_char(item):
     # takes a string with integers and characters and strips the characters from the end of it

--- a/pgquota/pgquota
+++ b/pgquota/pgquota
@@ -1,6 +1,8 @@
 #!/usr/bin/python3
 import subprocess, os, argparse, grp, getpass
 
+NA_value = 'N/A'
+
 fs_type = {
    '/home'    : 'lustre',
    '/home2'   : 'zfsnfs',
@@ -93,6 +95,15 @@ def percent_bar(percent):
     bar += num_string
     return bar
 
+def convert_bytes(num):
+    # this function will convert bytes to MiB.... GiB... etc
+    step_unit = 1024
+
+    for x in ['bytes', 'KiB', 'MiB', 'GiB', 'TiB']:
+        if num < step_unit:
+            return "{:.1f} {}".format (num, x)
+        num /= step_unit
+    return "{:.1f} {}".format (num, 'PiB')
 
 def strip_char(item):
     # takes a string with integers and characters and strips the characters from the end of it
@@ -145,9 +156,8 @@ class Quota:
         # functions to call
         self.gen_warnings()
 
-
     def quota_lustre(self,debug_flag):
-        self.raw = subprocess.check_output(['lfs', 'quota', '-g', str(self.group), str(self.directory), '-h']).decode(
+        self.raw = subprocess.check_output(['lfs', 'quota', '-g', str(self.group), str(self.directory)]).decode(
             "utf-8")
         if debug_flag:
             print(Color.red("Debug Raw"))
@@ -156,9 +166,9 @@ class Quota:
         self.check_raw()  # check the raw for errors before further processing
         # Initialize here just so we keep track of what's available in the object
         self.ref = [i for i in self.raw.split('\n')[2].split(' ') if i]
-        self.dusage = strip_char(self.ref[1])
-        self.dalloc = strip_char(self.ref[2])
-        self.dlimit = strip_char(self.ref[3])
+        self.dusage = int(self.ref[1])*1024
+        self.dalloc = int(self.ref[2])*1024
+        self.dlimit = int(self.ref[3])*1024
         self.dgrace = self.ref[4]
         if self.dgrace == "none":
             self.dgrace = self.dgrace.upper()
@@ -184,15 +194,15 @@ class Quota:
                     self.dusage = int(fields[3])
                     self.dalloc = int(fields[4])
                     self.dlimit = int(fields[4])
-                    self.dgrace = -1
+                    self.dgrace = NA_value
                     self.fusage = int(fields[5])
                     self.falloc = int(fields[6])
                     if self.falloc == 0:
-                       self.falloc = -1
+                       self.falloc = NA_value
                     self.flimit = int(fields[6])
                     if self.flimit == 0:
-                       self.flimit = -1
-                    self.fgrace = -1
+                       self.flimit = NA_value
+                    self.fgrace = NA_value
                     break
            self.sanity_check()
         except:
@@ -218,7 +228,7 @@ class Quota:
             self._warn_use = 'blue'
         # file warnings
         self._warn_files = 'blue'
-        if self.falloc > 0:
+        if self.falloc != NA_value:
            if self.fusage > self.falloc and self.falloc > 0:
                self._warn_files = 'red'
            elif float(float(float(self.falloc) - float(self.fusage)) / float(self.falloc) < 0.06):
@@ -229,16 +239,16 @@ class Quota:
         print(Color.bold(self.directory))
         # print bar
         print(Color.bold(Color.w_color(self.bar, self._warn_use)))
-        print("  Quota:	{}".format(self.dalloc))
-        print("  Hard Limit:	{}".format(self.dlimit))
-        print(Color.w_color("  Usage:\t{}".format(self.dusage), self._warn_use))
+        print("  Quota:	{}".format(convert_bytes(self.dalloc)))
+        print("  Hard Limit:	{}".format(convert_bytes(self.dlimit)))
+        print(Color.w_color("  Usage:\t{}".format(convert_bytes(self.dusage)), self._warn_use))
         print("  File Quota:	{}".format(self.falloc))
         print("  File Limit:	{}".format(self.flimit))
         print(Color.w_color("  Files:\t{}".format(self.fusage), self._warn_use))
         if self._warn_use == 'red' and self.dgrace != '-':
             print(Color.w_color(
                 "You have exceeded your storage limit of {}. Please reduce your storage usage below this limit or contact the system administrator to increase it within {}.".format(
-                    self.dalloc, self.dgrace), self._warn_use))
+                    convert_bytes(self.dalloc), self.dgrace), self._warn_use))
             if self.dgrace == "NONE":
                 print(Color.w_color(
                     "You have exceeded your grace period. You will be unable to write additional files to {} until you reduce storage usage below {}.".format(

--- a/pgquota/pgquota
+++ b/pgquota/pgquota
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-import subprocess, os, argparse, grp, getpass
+import subprocess, os, argparse, grp, getpass, pathlib
 
 NA_value = 'N/A'
 
@@ -296,11 +296,10 @@ def main():
     username = getpass.getuser()
     groups = os.getgroups()
 
-    if os.path.isdir(os.path.join('/home2', username)):
-       homefs = '/home2'
-    else:
-       homefs = '/home'
-
+    # Resolve real location of home directory, ignoring symlinks
+    # We could also check the location, but I don't like calling df like functionality,
+    # and we need internal system knowledge anyway.
+    homefs = str(pathlib.Path(*pathlib.Path.home().resolve().parts[:2]))
     directories = [
         homefs,
         '/data',

--- a/pgquota/pgquota
+++ b/pgquota/pgquota
@@ -1,5 +1,8 @@
 #!/usr/bin/python3
-import subprocess, os, argparse, grp, getpass, pathlib
+import subprocess, argparse, grp
+from getpass import getuser
+from os import getgroups
+from pathlib import Path
 
 NA_value = 'N/A'
 
@@ -185,7 +188,7 @@ class Quota:
 
 
     def quota_zfsnfs(self,debug_flag):
-        filename = os.path.join(self.directory,'.quota')
+        filename = Path(self.directory) / '.quota'
         try:
            with open(filename) as f:
               for line in f:
@@ -293,13 +296,13 @@ def gname(gid):
 
 
 def main():
-    username = getpass.getuser()
-    groups = os.getgroups()
+    username = getuser()
+    groups = getgroups()
 
     # Resolve real location of home directory, ignoring symlinks
     # We could also check the location, but I don't like calling df like functionality,
     # and we need internal system knowledge anyway.
-    homefs = str(pathlib.Path(*pathlib.Path.home().resolve().parts[:2]))
+    homefs = str(Path(*Path.home().resolve().parts[:2]))
     directories = [
         homefs,
         '/data',

--- a/pgquota/pgquota
+++ b/pgquota/pgquota
@@ -145,6 +145,7 @@ class Quota:
         # functions to call
         self.gen_warnings()
 
+
     def quota_lustre(self,debug_flag):
         self.raw = subprocess.check_output(['lfs', 'quota', '-g', str(self.group), str(self.directory), '-h']).decode(
             "utf-8")
@@ -155,7 +156,6 @@ class Quota:
         self.check_raw()  # check the raw for errors before further processing
         # Initialize here just so we keep track of what's available in the object
         self.ref = [i for i in self.raw.split('\n')[2].split(' ') if i]
-        self.sanity_check()
         self.dusage = strip_char(self.ref[1])
         self.dalloc = strip_char(self.ref[2])
         self.dlimit = strip_char(self.ref[3])
@@ -171,14 +171,30 @@ class Quota:
         self.fgrace = self.ref[8]
         if self.fgrace == "none":
             self.fgrace = self.fgrace.upper()
+        self.sanity_check()
 
 
     def quota_zfsnfs(self,debug_flag):
         filename = os.path.join(self.directory,'.quota')
         try:
            with open(filename) as f:
-              line = f.readline()
-              fields = line.trim().split('\\s+');
+              for line in f:
+                 fields = line.strip().split();
+                 if str(fields[2]) == str(self.group):
+                    self.dusage = int(fields[3])
+                    self.dalloc = int(fields[4])
+                    self.dlimit = int(fields[4])
+                    self.dgrace = -1
+                    self.fusage = int(fields[5])
+                    self.falloc = int(fields[6])
+                    if self.falloc == 0:
+                       self.falloc = -1
+                    self.flimit = int(fields[6])
+                    if self.flimit == 0:
+                       self.flimit = -1
+                    self.fgrace = -1
+                    break
+           self.sanity_check()
         except:
            raise(QuotaFileError)
 
@@ -189,7 +205,7 @@ class Quota:
 
     def sanity_check(self):
         # check if there even is a quota for this user group otherwise raise exception
-        if self.ref[2] in {None, '0'} or self.ref[6] in {None, '0'}:
+        if self.dalloc in {None, '0'} or self.falloc in {None, '0'}:
             raise DataError()
 
     def gen_warnings(self):
@@ -201,40 +217,40 @@ class Quota:
         else:
             self._warn_use = 'blue'
         # file warnings
-        if self.fusage > self.falloc:
-            self._warn_files = 'red'
-        elif float(float(float(self.falloc) - float(self.fusage)) / float(self.falloc) < 0.06):
-            self._warn_files = 'warn'
-        else:
-            self._warn_files = 'blue'
+        self._warn_files = 'blue'
+        if self.falloc > 0:
+           if self.fusage > self.falloc and self.falloc > 0:
+               self._warn_files = 'red'
+           elif float(float(float(self.falloc) - float(self.fusage)) / float(self.falloc) < 0.06):
+               self._warn_files = 'warn'
 
     def full_print(self):
         # print directory
         print(Color.bold(self.directory))
         # print bar
         print(Color.bold(Color.w_color(self.bar, self._warn_use)))
-        print("  Quota:	{}".format(self.ref[2]))
-        print("  Hard Limit:	{}".format(self.ref[3]))
-        print(Color.w_color("  Usage:\t{}".format(self.ref[1]), self._warn_use))
+        print("  Quota:	{}".format(self.dalloc))
+        print("  Hard Limit:	{}".format(self.dlimit))
+        print(Color.w_color("  Usage:\t{}".format(self.dusage), self._warn_use))
         print("  File Quota:	{}".format(self.falloc))
         print("  File Limit:	{}".format(self.flimit))
-        print(Color.w_color("  Files:\t{}".format(self.ref[5]), self._warn_use))
+        print(Color.w_color("  Files:\t{}".format(self.fusage), self._warn_use))
         if self._warn_use == 'red' and self.dgrace != '-':
             print(Color.w_color(
                 "You have exceeded your storage limit of {}. Please reduce your storage usage below this limit or contact the system administrator to increase it within {}.".format(
-                    self.ref[2], self.dgrace), self._warn_use))
+                    self.dalloc, self.dgrace), self._warn_use))
             if self.dgrace == "NONE":
                 print(Color.w_color(
                     "You have exceeded your grace period. You will be unable to write additional files to {} until you reduce storage usage below {}.".format(
-                        self.directory, self.ref[2]), self._warn_use))
+                        self.directory, self.dalloc), self._warn_use))
         if self._warn_files == 'red' and self.fgrace != '-':
             print(Color.w_color(
                 "You have exceeded your file limit of {}. Please reduce the number of files below this limit or contact the system administrator to increase it within {}.".format(
-                    self.ref[6], self.fgrace), self._warn_files))
+                    self.falloc, self.fgrace), self._warn_files))
             if self.fgrace == "NONE":
                 print(Color.w_color(
                     "You have exceeded your grace period. You will be unable to write additional files to {} until you reduce file usage below {}.".format(
-                        self.directory, self.ref[6]), self._warn_use))
+                        self.directory, self.falloc), self._warn_use))
 
     def return_warnings(self):
         return self._warn_use, self._warn_files
@@ -326,7 +342,7 @@ def main():
                         print(Color.w_color("You have exceeded your storage quota on the {}".format(d), dwarn),
                               Color.w_color(
                                   " filesystem and your grace period is over. Please reduce usage below {} or contact system administrator.".format(
-                                      quota.ref[2]), dwarn))
+                                      quota.dalloc), dwarn))
                     else:
                         print(Color.w_color("You have exceeded your storage quota on the {}".format(d), dwarn),
                               Color.w_color(" filesystem, please reduce usage within {}.".format(quota.dgrace), dwarn))

--- a/pgquota/pgquota
+++ b/pgquota/pgquota
@@ -1,5 +1,13 @@
 #!/usr/bin/python3
-import subprocess, os, argparse, grp
+import subprocess, os, argparse, grp, getpass
+
+fs_type = {
+   '/home'    : 'lustre',
+   '/home2'   : 'zfsnfs',
+   '/data'    : 'lustre',
+   '/scratch' : 'lustre',
+}
+
 
 class Color():
     colors = {
@@ -43,6 +51,12 @@ class PermissionError(Exception):
 
 
 class DataError(Exception):
+    pass
+
+class QuotaFileError(Exception):
+    pass
+
+class UnsupportedFsType(Exception):
     pass
 
 
@@ -107,18 +121,15 @@ class Quota:
     # Then we can print it or not
     def __init__(self, group, directory, debug_flag):
         self.group = group
-        print(self.group)
-        if directory == '/home':
-           if os.path.isdir(os.path.join('/home2', gname(self.group))):
-              self.directory = '/home'
-        else:
-           self.directory = directory
-      
-        if self.directory == '/home2': 
+        self.directory = directory
+       
+        if fs_type[self.directory] == 'lustre':
+           self.quota_lustre(debug_flag)
+        elif fs_type[self.directory] == 'zfsnfs':
            self.quota_zfsnfs(debug_flag)
         else:
-           self.quota_lustre(debug_flag)
-        
+           raise UnsupportedFsType
+
         if debug_flag:
             print(Color.red("Debug object variables"))
             print(
@@ -163,7 +174,13 @@ class Quota:
 
 
     def quota_zfsnfs(self,debug_flag):
-        return
+        filename = os.path.join(self.directory,'.quota')
+        try:
+           with open(filename) as f:
+              line = f.readline()
+              fields = line.trim().split('\\s+');
+        except:
+           raise(QuotaFileError)
 
     def check_raw(self):
         # checks for messages like "Permission denied."
@@ -250,12 +267,20 @@ def gname(gid):
 
 
 def main():
+    username = getpass.getuser()
     groups = os.getgroups()
+
+    if os.path.isdir(os.path.join('/home2', username)):
+       homefs = '/home2'
+    else:
+       homefs = '/home'
+
     directories = [
-        '/home',
+        homefs,
         '/data',
         '/scratch'
     ]
+
     parser = argparse.ArgumentParser()
     # mutex = parser.add_mutually_exclusive_group()
     # mutex.add_argument('-u',type=str,help="Specify user. Only prints quota for specified user's own group.",const=groups)
@@ -284,6 +309,14 @@ def main():
             except DataError:
                 if not args.r:
                     print("No data for {} {} in directory {}".format(entity, Color.bold(eid), Color.bold(d)))
+                continue
+            except QuotaFileError:
+                if not args.r:
+                    print("Error reading quota file for {}".format(Color.bold(d)))
+                continue
+            except UnsupportedFsType:
+                if not args.r:
+                    print("Unsupported file system type for {}".format(Color.bold(d)))
                 continue
             if args.r:
                 dwarn, fwarn = quota.return_warnings()

--- a/pgquota/pgquota.spec
+++ b/pgquota/pgquota.spec
@@ -34,6 +34,12 @@ install pgquota $RPM_BUILD_ROOT/usr/bin/pgquota
 rm -rf $RPM_BUILD_ROOT
 
 %changelog
+* Wed Jan 12 2022 Fokke Dijkstra <f.dijkstra@rug.nl> - 1.3-1
+- Adjusted pgquota to be able to work on a NFS exported
+  ZFS file system. Since ZFS does not export the quota 
+  through NFS The quota must be dumped into a file on
+  the file system in a cron job.
+
 * Mon Sep 20 2021 Klemen Voncina <k.voncina@rug.nl> - 1.2-1
 - Updated to use with Python3 (minor version bump)
 - Fixed an issue where student numbers would get cut off too far


### PR DESCRIPTION
Since we mount a ZFS file system over NFS for /home2 we need a different way of showing the quota status.
The quota for each group are reported in /home2/.quota.  The tool has been adjusted to be able to read and report quota information from that file. 
It detects in which file system the users home directory is located and will read the file system type from a dictionary. It will then report the correct quota for the given file system type.