### PR TITLE
Fixed output when a user on Lustre is out of quota

### DIFF
--- a/pgquota/pgquota
+++ b/pgquota/pgquota
@@ -108,20 +108,12 @@ def convert_bytes(num):
         num /= step_unit
     return "{:.1f} {}".format(num, 'PiB')
 
-def strip_char(item):
-    # takes a string with integers and characters and strips the characters from the end of it
-    suffixes = {
-        # not exact but close enough to unify and calculate a percentage. Axed 3 zeroes off the end just because its uneccessary
-        'k': 1,
-        'M': 1000,
-        'G': 1000000,
-        'T': 1000000000
-    }
+def strip_star(item):
+    # Removes the * from the end of a string if it is there
     if item[-1] == '*':
-        item = item[:-1]
-    item = suffixes.get(item[-1]) * float(item[:-1])
-    return item
-
+        return item[:-1]
+    else:
+        return item
 
 def date_pretty(date_string):
     # TODO: Implement this
@@ -169,16 +161,13 @@ class Quota:
         self.check_raw()  # check the raw for errors before further processing
         # Initialize here just so we keep track of what's available in the object
         self.ref = [i for i in self.raw.split('\n')[2].split(' ') if i]
-        self.dusage = int(self.ref[1])*1024
-        self.dalloc = int(self.ref[2])*1024
-        self.dlimit = int(self.ref[3])*1024
+        self.dusage = int(strip_star(self.ref[1]))*1024
+        self.dalloc = int(strip_star(self.ref[2]))*1024
+        self.dlimit = int(strip_star(self.ref[3]))*1024
         self.dgrace = self.ref[4]
         if self.dgrace == "none":
             self.dgrace = self.dgrace.upper()
-        if self.ref[5][-1] == '*':
-            self.fusage = int(self.ref[5][:-1])
-        else:
-            self.fusage = int(self.ref[5])
+        self.fusage = int(strip_star(self.ref[5]))
         self.falloc = int(self.ref[6])
         self.flimit = int(self.ref[7])
         self.fgrace = self.ref[8]


### PR DESCRIPTION
Changed the function strip_char into strip_star, which removes the * at the end of a string.
Used this function to remove the * from "out of quota" numbers that Lustre may report.